### PR TITLE
キャンバスを8x8に変更し、16色パレットを実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,25 @@
         <div id="editor"></div>
         <div class="controls">
             <div class="color-picker">
-                <label for="colorPicker">色を選択:</label>
-                <input type="color" id="colorPicker" value="#000000">
+                <label>色を選択:</label>
+                <div class="color-palette">
+                    <button class="color-btn" data-color="rgba(0,0,0,1)" style="background-color: #000000"></button>
+                    <button class="color-btn" data-color="rgba(255,255,255,1)" style="background-color: #FFFFFF"></button>
+                    <button class="color-btn" data-color="rgba(255,0,0,1)" style="background-color: #FF0000"></button>
+                    <button class="color-btn" data-color="rgba(0,255,0,1)" style="background-color: #00FF00"></button>
+                    <button class="color-btn" data-color="rgba(0,0,255,1)" style="background-color: #0000FF"></button>
+                    <button class="color-btn" data-color="rgba(0,255,255,1)" style="background-color: #00FFFF"></button>
+                    <button class="color-btn" data-color="rgba(255,0,255,1)" style="background-color: #FF00FF"></button>
+                    <button class="color-btn" data-color="rgba(255,255,0,1)" style="background-color: #FFFF00"></button>
+                    <button class="color-btn" data-color="rgba(128,0,0,1)" style="background-color: #800000"></button>
+                    <button class="color-btn" data-color="rgba(0,128,0,1)" style="background-color: #008000"></button>
+                    <button class="color-btn" data-color="rgba(0,0,128,1)" style="background-color: #000080"></button>
+                    <button class="color-btn" data-color="rgba(255,128,128,1)" style="background-color: #FF8080"></button>
+                    <button class="color-btn" data-color="rgba(128,255,128,1)" style="background-color: #80FF80"></button>
+                    <button class="color-btn" data-color="rgba(128,128,255,1)" style="background-color: #8080FF"></button>
+                    <button class="color-btn" data-color="rgba(128,128,128,1)" style="background-color: #808080"></button>
+                    <button class="color-btn transparent" data-color="rgba(255,255,255,0)"></button>
+                </div>
             </div>
             <button id="clearButton">クリア</button>
             <button id="saveButton">保存</button>

--- a/sketch.js
+++ b/sketch.js
@@ -1,8 +1,10 @@
 let canvas;
 let pixelSize = 16; // 表示サイズを大きくするための倍率
-let gridSize = 32;  // アイコンの実際のサイズ
+let gridSize = 8;  // アイコンの実際のサイズ
 let drawing = false;
 let pixels = [];
+
+let currentColor;
 
 function setup() {
     // キャンバスを作成し、指定された要素内に配置
@@ -21,6 +23,23 @@ function setup() {
     document.getElementById('clearButton').addEventListener('click', clearCanvas);
     document.getElementById('saveButton').addEventListener('click', saveIcon);
     
+    // カラーパレットのボタンにイベントリスナーを設定
+    const colorButtons = document.querySelectorAll('.color-btn');
+    colorButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            // 以前の選択を解除
+            document.querySelector('.color-btn.selected')?.classList.remove('selected');
+            // 新しい選択を設定
+            button.classList.add('selected');
+            currentColor = color(button.dataset.color);
+        });
+    });
+    
+    // 初期カラーを設定
+    const firstColorBtn = document.querySelector('.color-btn');
+    firstColorBtn.classList.add('selected');
+    currentColor = color(firstColorBtn.dataset.color);
+    
     // 描画設定
     noSmooth();
 }
@@ -34,7 +53,6 @@ function draw() {
         const x = floor(mouseX / pixelSize);
         const y = floor(mouseY / pixelSize);
         if (x >= 0 && x < gridSize && y >= 0 && y < gridSize) {
-            const currentColor = color(document.getElementById('colorPicker').value);
             pixels[x][y] = currentColor;
         }
     }

--- a/style.css
+++ b/style.css
@@ -28,8 +28,41 @@ body {
 
 .color-picker {
     display: flex;
-    align-items: center;
+    flex-direction: column;
     gap: 8px;
+}
+
+.color-palette {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 4px;
+}
+
+.color-btn {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.color-btn:hover {
+    transform: scale(1.1);
+}
+
+.color-btn.selected {
+    border: 2px solid #000;
+}
+
+.color-btn.transparent {
+    background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
+                      linear-gradient(-45deg, #ccc 25%, transparent 25%),
+                      linear-gradient(45deg, transparent 75%, #ccc 75%),
+                      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+    background-size: 8px 8px;
+    background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
+    background-color: white;
 }
 
 button {


### PR DESCRIPTION
## 変更内容

- キャンバスサイズを8x8に変更し、より小さなアイコンの作成に対応
- カラーピッカーを16色のパレットに変更し、色の選択をより直感的に
- パレットには基本的な16色(黒、白、赤、緑、青、シアン、マゼンタ、イエロー、暗い色3色、明るい色3色、グレー、透明)を実装
- カラー選択の処理を実装し、選択中の色を視覚的に表示